### PR TITLE
Switch to .NET standard 2.0 for compatibility with .NET v4.8

### DIFF
--- a/src/EmberLib.net/BerLib/BerLib.csproj
+++ b/src/EmberLib.net/BerLib/BerLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Company>Lawo GmbH</Company>
     <Copyright>Copyright © Lawo GmbH</Copyright>
     <Product>EmberLib.net BerLib</Product>

--- a/src/EmberLib.net/EmberLib.Framing/EmberLib.Framing.csproj
+++ b/src/EmberLib.net/EmberLib.Framing/EmberLib.Framing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Product>EmberLib.net EmberLib.Framing</Product>
     <Company>Lawo GmbH</Company>
     <Copyright>Copyright © Lawo GmbH</Copyright>

--- a/src/EmberLib.net/EmberLib.Glow/EmberLib.Glow.csproj
+++ b/src/EmberLib.net/EmberLib.Glow/EmberLib.Glow.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Product>EmberLib.net EmberLib.Glow</Product>
     <Copyright>Copyright © Lawo GmbH</Copyright>
     <Company>Lawo GmbH</Company>

--- a/src/EmberLib.net/EmberLib/EmberLib.csproj
+++ b/src/EmberLib.net/EmberLib/EmberLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyVersion>1.8.3.0</AssemblyVersion>
     <Product>EmberLib.net EmberLib</Product>
     <Copyright>Copyright © Lawo GmbH</Copyright>

--- a/src/EmberPlusProviderClassLib/EmberPlusProviderClassLib.csproj
+++ b/src/EmberPlusProviderClassLib/EmberPlusProviderClassLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Nuget.EmberPlusProviderLib.NetStandard/Nuget.EmberPlusProviderLib.NetStandard.csproj
+++ b/src/Nuget.EmberPlusProviderLib.NetStandard/Nuget.EmberPlusProviderLib.NetStandard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <PackageId>EmberPlus.ProviderLib</PackageId>
     <Description>C# .NET Standard provider library for the EmBER+ protocol.</Description>


### PR DESCRIPTION
### 📑 Description
Libraries built to .NET Standard 2.1 can't link with legacy .NET Framework v4.x applications. In order to be able to use this with a legacy .NET v4.8 project, this switches the library to .NET Standard 2.0 instead.

### ✅ Checks

I have tested that this code still builds and works with a basic test application showing a single parameter.

